### PR TITLE
[FEAT] 이슈템플릿 및 PR 템플릿 구현

### DIFF
--- a/.github/ISSUE_TEMPLATES/feature.md
+++ b/.github/ISSUE_TEMPLATES/feature.md
@@ -1,0 +1,18 @@
+---
+name: Feature
+about: 기능 개발
+title: "[FEATURE]"
+labels: ''
+assignees: ''
+
+---
+
+## Description
+설명 작성
+
+## To - Do
+1.
+2.
+3.
+
+## ETC

--- a/.github/ISSUE_TEMPLATES/fix.md
+++ b/.github/ISSUE_TEMPLATES/fix.md
@@ -1,0 +1,18 @@
+---
+name: Fix
+about: 기능 수정
+title: "[FIX]"
+labels: ''
+assignees: ''
+
+---
+
+## Description
+설명 작성
+
+## To - Do
+1.
+2.
+3.
+
+## ETC

--- a/.github/ISSUE_TEMPLATES/hotfix.md
+++ b/.github/ISSUE_TEMPLATES/hotfix.md
@@ -1,0 +1,18 @@
+---
+name: HotFix
+about: 오류 수정
+title: "[HOTFIX]"
+labels: ''
+assignees: ''
+
+---
+
+## Description
+설명 작성
+
+## To - Do
+1.
+2.
+3.
+
+## ETC

--- a/.github/ISSUE_TEMPLATES/refactor.md
+++ b/.github/ISSUE_TEMPLATES/refactor.md
@@ -1,0 +1,18 @@
+---
+name: Refactor
+about: 코드 리팩터링
+title: "[REFACTOR]"
+labels: ''
+assignees: ''
+
+---
+
+## Description
+설명 작성
+
+## To - Do
+1.
+2.
+3.
+
+## ETC

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Issue
+
+- 이슈 번호 및 링크
+
+## Summary
+
+- 요약
+
+## Describe your code
+
+- 코드 설명 또는 PR 포인트
+
+## What I Learned
+
+- 구현하면서 새롭게 알게 된 점 및 트러블 슈팅
+


### PR DESCRIPTION
## Issue

- #1

## Summary

- 이슈 템플릿과 PR 템플릿 구현

## Describe your code

- 기존의 컨벤션에 맞추어 템플릿을 구현했습니다

## 알게된 점

- PR 제목에 대한 컨벤션을 안정한 것 같아서 한 번 정해봐야 할 것 같습니다
- 템플릿을 추가하며 브랜치 룰셋도 적용하려 합니다.
    - 리뷰 하나
    - CI 확인
- 이렇게 룰셋 적용하려 하는데 어떻게 생각하시나요?

