### PR TITLE
[FEAT] CorsConfig 구현

### DIFF
--- a/src/main/java/or/sopt/soptwatcha/config/CorsConfig.java
+++ b/src/main/java/or/sopt/soptwatcha/config/CorsConfig.java
@@ -1,0 +1,20 @@
+package or.sopt.soptwatcha.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                // web에서 배포되는 주소에 따라 추가해주어야 합니다
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+
+}


### PR DESCRIPTION
## ✨ Issue

- #12 

<br>

## 📕 Summary

- CorsConfig 구현을 통한 CORS 에러 해결

<br>

## 🖥️ Describe your code

- `.allowedOrigins("http://localhost:3000")` 해당 메서드 파라미터에 웹에서 배포하는 주소를 추가하면 CORS를 다른 도메인에 대해서도 허용해 줄 수 있습니다
- 주소가 많아지면 여러 주소를 묶어서 한 번에 관리하면 좋을 것 같습니다!

<br>

## ✏️ What I Learned

- 구현하다가 영주님께서 올려주신 아티클도 한 번 보게됐는데, 이걸 Nginx에서도 해결 할 수 있더라구요. 고민해보다가 그냥 하던대로 config로 하긴 했는데 흠 고민되네요 지금이라도 Nginx에서 해볼까~..

