### PR TITLE
[FEAT] 에러 핸들링 초기 설정

### DIFF
--- a/src/main/java/or/sopt/soptwatcha/common/exception/CustomException.java
+++ b/src/main/java/or/sopt/soptwatcha/common/exception/CustomException.java
@@ -1,20 +1,19 @@
 package or.sopt.soptwatcha.common.exception;
 
+import lombok.Getter;
+
+@Getter
 public class CustomException extends RuntimeException {
     private final ErrorCode errorCode;
-    private final String message;
 
     public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
         this.errorCode = errorCode;
-        this.message = errorCode.getMessage();
     }
 
-    public ErrorCode getErrorCode() {
-        return errorCode;
+    public CustomException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
     }
 
-    @Override
-    public String getMessage() {
-        return message;
-    }
 }

--- a/src/main/java/or/sopt/soptwatcha/common/exception/CustomException.java
+++ b/src/main/java/or/sopt/soptwatcha/common/exception/CustomException.java
@@ -1,0 +1,20 @@
+package or.sopt.soptwatcha.common.exception;
+
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final String message;
+
+    public CustomException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.message = errorCode.getMessage();
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/or/sopt/soptwatcha/common/exception/ErrorCode.java
+++ b/src/main/java/or/sopt/soptwatcha/common/exception/ErrorCode.java
@@ -1,33 +1,26 @@
 package or.sopt.soptwatcha.common.exception;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+@Getter
+@RequiredArgsConstructor
 public enum ErrorCode {
-    //common
-    METHOD_NOT_ALLOWED(100, HttpStatus.METHOD_NOT_ALLOWED.value(), "유효하지 않은 Http 메서드입니다."),
-    API_NOT_FOUND(101, HttpStatus.NOT_FOUND.value(), "존재하지 않는 API 입니다."),
-    INTERNAL_SERVER_ERROR(102, HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류입니다."),
-    ;
+    // 클라이언트 오류 - 400번대
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "유효하지 않은 Http 메서드입니다."),
+    API_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 API 입니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된.파라미터입니다."),
 
-    private final int code;
-    private final int httpStatus;
+    // 서버 오류 - 500번대
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+
+    private final HttpStatus httpStatus;
     private final String message;
 
-    ErrorCode(int code, int httpStatus, String message) {
-        this.code = code;
-        this.httpStatus = httpStatus;
-        this.message = message;
+    public int getStatusCode() {
+        return httpStatus.value();
     }
 
-    public int getCode() {
-        return code;
-    }
-
-    public int getHttpStatus() {
-        return httpStatus;
-    }
-
-    public String getMessage() {
-        return message;
-    }
 }

--- a/src/main/java/or/sopt/soptwatcha/common/exception/ErrorCode.java
+++ b/src/main/java/or/sopt/soptwatcha/common/exception/ErrorCode.java
@@ -1,0 +1,33 @@
+package or.sopt.soptwatcha.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+    //common
+    METHOD_NOT_ALLOWED(100, HttpStatus.METHOD_NOT_ALLOWED.value(), "유효하지 않은 Http 메서드입니다."),
+    API_NOT_FOUND(101, HttpStatus.NOT_FOUND.value(), "존재하지 않는 API 입니다."),
+    INTERNAL_SERVER_ERROR(102, HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류입니다."),
+    ;
+
+    private final int code;
+    private final int httpStatus;
+    private final String message;
+
+    ErrorCode(int code, int httpStatus, String message) {
+        this.code = code;
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/or/sopt/soptwatcha/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/or/sopt/soptwatcha/common/exception/GlobalControllerAdvice.java
@@ -31,8 +31,7 @@ public class GlobalControllerAdvice {
         BaseErrorResponse response = new BaseErrorResponse(
                 false,
                 BAD_REQUEST.value(),
-                message,
-                java.time.LocalDateTime.now()
+                message
         );
 
         return new ResponseEntity<>(response, HttpStatusCode.valueOf(BAD_REQUEST.value()));

--- a/src/main/java/or/sopt/soptwatcha/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/or/sopt/soptwatcha/common/exception/GlobalControllerAdvice.java
@@ -1,0 +1,56 @@
+package or.sopt.soptwatcha.common.exception;
+
+import or.sopt.soptwatcha.common.response.BaseErrorResponse;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import static or.sopt.soptwatcha.common.exception.ErrorCode.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@RestControllerAdvice
+public class GlobalControllerAdvice {
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<BaseErrorResponse> handleCustomExceptions(CustomException e) {
+        return new ResponseEntity<>(new BaseErrorResponse(e.getErrorCode()), HttpStatusCode.valueOf(e.getErrorCode().getHttpStatus()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<BaseErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .orElse("입력값이 잘못되었습니다.");
+
+        BaseErrorResponse response = new BaseErrorResponse(
+                false,
+                BAD_REQUEST.value(),
+                message,
+                java.time.LocalDateTime.now()
+        );
+
+        return new ResponseEntity<>(response, HttpStatusCode.valueOf(BAD_REQUEST.value()));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public BaseErrorResponse handle_HttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        return new BaseErrorResponse(METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public BaseErrorResponse handle_NoHandlerFoundException(NoHandlerFoundException e){
+        return new BaseErrorResponse(API_NOT_FOUND);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public BaseErrorResponse handle_InternalError(InternalError e) {
+        return new BaseErrorResponse(INTERNAL_SERVER_ERROR);
+    }
+
+}

--- a/src/main/java/or/sopt/soptwatcha/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/or/sopt/soptwatcha/common/exception/GlobalControllerAdvice.java
@@ -2,63 +2,90 @@ package or.sopt.soptwatcha.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import or.sopt.soptwatcha.common.response.BaseErrorResponse;
-import org.springframework.context.support.DefaultMessageSourceResolvable;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
-import static or.sopt.soptwatcha.common.exception.ErrorCode.*;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalControllerAdvice {
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<BaseErrorResponse> handleCustomExceptions(CustomException e) {
-        return new ResponseEntity<>(new BaseErrorResponse(e.getErrorCode()), HttpStatusCode.valueOf(e.getErrorCode().getHttpStatus()));
+    public ResponseEntity<BaseErrorResponse> handleCustomException(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.error("[CustomException] {} - {}", errorCode.name(), e.getMessage());
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(BaseErrorResponse.of(errorCode));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<BaseErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
-        String message = ex.getBindingResult().getFieldErrors()
-                .stream()
+    public ResponseEntity<BaseErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult().getFieldErrors().stream()
                 .findFirst()
-                .map(DefaultMessageSourceResolvable::getDefaultMessage)
-                .orElse("입력값이 잘못되었습니다.");
+                .map(error -> error.getDefaultMessage())
+                .orElse("입력값이 올바르지 않습니다.");
 
-        BaseErrorResponse response = new BaseErrorResponse(
+        log.error("[ValidationException] {}", errorMessage);
+
+        BaseErrorResponse errorResponse = BaseErrorResponse.of(
                 false,
-                BAD_REQUEST.value(),
-                message
+                ErrorCode.INVALID_PARAMETER.getStatusCode(),
+                errorMessage
         );
 
-        return new ResponseEntity<>(response, HttpStatusCode.valueOf(BAD_REQUEST.value()));
+        return ResponseEntity
+                .status(ErrorCode.INVALID_PARAMETER.getHttpStatus())
+                .body(errorResponse);
+    }
+
+    @ExceptionHandler({
+            BindException.class,
+            MethodArgumentTypeMismatchException.class,
+            HttpMessageNotReadableException.class,
+            MissingServletRequestParameterException.class
+    })
+    public ResponseEntity<BaseErrorResponse> handleBadRequestException(Exception e) {
+        log.error("[BadRequest] {}", e.getMessage());
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_REQUEST.getHttpStatus())
+                .body(BaseErrorResponse.of(ErrorCode.INVALID_REQUEST));
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public ResponseEntity<BaseErrorResponse> handle_HttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+    public ResponseEntity<BaseErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("[MethodNotAllowed] {}", e.getMessage());
+
         return ResponseEntity
-                .status(METHOD_NOT_ALLOWED.getHttpStatus())
-                .body(new BaseErrorResponse(METHOD_NOT_ALLOWED));
+                .status(ErrorCode.METHOD_NOT_ALLOWED.getHttpStatus())
+                .body(BaseErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED));
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)
-    public ResponseEntity<BaseErrorResponse> handle_NoHandlerFoundException(NoHandlerFoundException e){
+    public ResponseEntity<BaseErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException e) {
+        log.error("[ApiNotFound] {}", e.getMessage());
+
         return ResponseEntity
-                .status(API_NOT_FOUND.getHttpStatus())
-                .body(new BaseErrorResponse(API_NOT_FOUND));
+                .status(ErrorCode.API_NOT_FOUND.getHttpStatus())
+                .body(BaseErrorResponse.of(ErrorCode.API_NOT_FOUND));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<BaseErrorResponse> handle_InternalError(Exception e) {
-        return ResponseEntity
-                .status(INTERNAL_SERVER_ERROR.getHttpStatus())
-                .body(new BaseErrorResponse(INTERNAL_SERVER_ERROR));
+    public ResponseEntity<BaseErrorResponse> handleException(Exception e) {
+        log.error("[InternalServerError] ", e);
 
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(BaseErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 
 }

--- a/src/main/java/or/sopt/soptwatcha/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/or/sopt/soptwatcha/common/exception/GlobalControllerAdvice.java
@@ -1,5 +1,6 @@
 package or.sopt.soptwatcha.common.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import or.sopt.soptwatcha.common.response.BaseErrorResponse;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatusCode;
@@ -13,6 +14,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 import static or.sopt.soptwatcha.common.exception.ErrorCode.*;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalControllerAdvice {
     @ExceptionHandler(CustomException.class)
@@ -38,18 +40,25 @@ public class GlobalControllerAdvice {
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public BaseErrorResponse handle_HttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
-        return new BaseErrorResponse(METHOD_NOT_ALLOWED);
+    public ResponseEntity<BaseErrorResponse> handle_HttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        return ResponseEntity
+                .status(METHOD_NOT_ALLOWED.getHttpStatus())
+                .body(new BaseErrorResponse(METHOD_NOT_ALLOWED));
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)
-    public BaseErrorResponse handle_NoHandlerFoundException(NoHandlerFoundException e){
-        return new BaseErrorResponse(API_NOT_FOUND);
+    public ResponseEntity<BaseErrorResponse> handle_NoHandlerFoundException(NoHandlerFoundException e){
+        return ResponseEntity
+                .status(API_NOT_FOUND.getHttpStatus())
+                .body(new BaseErrorResponse(API_NOT_FOUND));
     }
 
     @ExceptionHandler(Exception.class)
-    public BaseErrorResponse handle_InternalError(InternalError e) {
-        return new BaseErrorResponse(INTERNAL_SERVER_ERROR);
+    public ResponseEntity<BaseErrorResponse> handle_InternalError(Exception e) {
+        return ResponseEntity
+                .status(INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(new BaseErrorResponse(INTERNAL_SERVER_ERROR));
+
     }
 
 }

--- a/src/main/java/or/sopt/soptwatcha/common/response/BaseErrorResponse.java
+++ b/src/main/java/or/sopt/soptwatcha/common/response/BaseErrorResponse.java
@@ -1,0 +1,45 @@
+package or.sopt.soptwatcha.common.response;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import or.sopt.soptwatcha.common.exception.ErrorCode;
+
+import java.time.LocalDateTime;
+
+@JsonPropertyOrder({"success", "code", "message", "timestamp"})
+public class BaseErrorResponse {
+    private final boolean success;
+    private final int code;
+    private final String message;
+    private final LocalDateTime timestamp;
+
+    public BaseErrorResponse(boolean success, int code, String message, LocalDateTime timestamp) {
+        this.success = false;
+        this.code = code;
+        this.message = message;
+        this.timestamp = timestamp;
+    }
+
+    public BaseErrorResponse(ErrorCode errorCode) {
+        this.code = errorCode.getHttpStatus();
+        this.message = errorCode.getMessage();
+        this.success = false;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+}

--- a/src/main/java/or/sopt/soptwatcha/common/response/BaseErrorResponse.java
+++ b/src/main/java/or/sopt/soptwatcha/common/response/BaseErrorResponse.java
@@ -2,7 +2,6 @@ package or.sopt.soptwatcha.common.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import lombok.Builder;
 import lombok.Getter;
 import or.sopt.soptwatcha.common.exception.ErrorCode;
 
@@ -19,7 +18,7 @@ public class BaseErrorResponse {
     private final LocalDateTime timestamp;
 
     public BaseErrorResponse(boolean success, int code, String message) {
-        this.success = false;
+        this.success = success;
         this.code = code;
         this.message = message;
         this.timestamp = LocalDateTime.now();

--- a/src/main/java/or/sopt/soptwatcha/common/response/BaseErrorResponse.java
+++ b/src/main/java/or/sopt/soptwatcha/common/response/BaseErrorResponse.java
@@ -2,14 +2,12 @@ package or.sopt.soptwatcha.common.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import lombok.Builder;
 import lombok.Getter;
 import or.sopt.soptwatcha.common.exception.ErrorCode;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
 @JsonPropertyOrder({"success", "code", "message", "timestamp", "errors"})
 public class BaseErrorResponse {
     private final boolean success;

--- a/src/main/java/or/sopt/soptwatcha/common/response/BaseErrorResponse.java
+++ b/src/main/java/or/sopt/soptwatcha/common/response/BaseErrorResponse.java
@@ -1,45 +1,40 @@
 package or.sopt.soptwatcha.common.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
+import lombok.Getter;
 import or.sopt.soptwatcha.common.exception.ErrorCode;
 
 import java.time.LocalDateTime;
 
+@Getter
 @JsonPropertyOrder({"success", "code", "message", "timestamp"})
 public class BaseErrorResponse {
     private final boolean success;
     private final int code;
     private final String message;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime timestamp;
 
-    public BaseErrorResponse(boolean success, int code, String message, LocalDateTime timestamp) {
+    public BaseErrorResponse(boolean success, int code, String message) {
         this.success = false;
         this.code = code;
         this.message = message;
-        this.timestamp = timestamp;
-    }
-
-    public BaseErrorResponse(ErrorCode errorCode) {
-        this.code = errorCode.getHttpStatus();
-        this.message = errorCode.getMessage();
-        this.success = false;
         this.timestamp = LocalDateTime.now();
     }
 
-    public boolean isSuccess() {
-        return success;
+    public BaseErrorResponse(ErrorCode errorCode) {
+        this(false, errorCode.getHttpStatus(), errorCode.getMessage());
     }
 
-    public int getCode() {
-        return code;
+    public static BaseErrorResponse of(boolean success, int code, String message) {
+        return new BaseErrorResponse(success, code, message);
     }
 
-    public String getMessage() {
-        return message;
-    }
-
-    public LocalDateTime getTimestamp() {
-        return timestamp;
+    public static BaseErrorResponse of(ErrorCode errorCode) {
+        return new BaseErrorResponse(errorCode);
     }
 
 }

--- a/src/main/java/or/sopt/soptwatcha/common/response/BaseErrorResponse.java
+++ b/src/main/java/or/sopt/soptwatcha/common/response/BaseErrorResponse.java
@@ -2,13 +2,15 @@ package or.sopt.soptwatcha.common.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
 import lombok.Getter;
 import or.sopt.soptwatcha.common.exception.ErrorCode;
 
 import java.time.LocalDateTime;
 
 @Getter
-@JsonPropertyOrder({"success", "code", "message", "timestamp"})
+@Builder
+@JsonPropertyOrder({"success", "code", "message", "timestamp", "errors"})
 public class BaseErrorResponse {
     private final boolean success;
     private final int code;
@@ -25,7 +27,7 @@ public class BaseErrorResponse {
     }
 
     public BaseErrorResponse(ErrorCode errorCode) {
-        this(false, errorCode.getHttpStatus(), errorCode.getMessage());
+        this(false, errorCode.getStatusCode(), errorCode.getMessage());
     }
 
     public static BaseErrorResponse of(boolean success, int code, String message) {

--- a/src/main/java/or/sopt/soptwatcha/common/response/BaseResponse.java
+++ b/src/main/java/or/sopt/soptwatcha/common/response/BaseResponse.java
@@ -1,0 +1,40 @@
+package or.sopt.soptwatcha.common.response;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.springframework.http.HttpStatus;
+
+@JsonPropertyOrder({"success", "code", "message", "data"})
+public class BaseResponse<T> {
+    private final Boolean success;
+    private final int code;
+    private final String message;
+    private final T data;
+
+    private BaseResponse(T data) {
+        this.success = true;
+        this.code = HttpStatus.OK.value();
+        this.message = "요청에 성공하였습니다.";
+        this.data = data;
+    }
+
+    public Boolean getSuccess() {
+        return success;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public static <T> BaseResponse<T> ok(T data) {
+        return new BaseResponse<>(data);
+    }
+
+}

--- a/src/main/java/or/sopt/soptwatcha/common/response/BaseResponse.java
+++ b/src/main/java/or/sopt/soptwatcha/common/response/BaseResponse.java
@@ -1,7 +1,7 @@
 package or.sopt.soptwatcha.common.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import lombok.Builder;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
@@ -11,6 +11,8 @@ public class BaseResponse<T> {
     private final Boolean success;
     private final int code;
     private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final T data;
 
     private BaseResponse(Boolean success, int code, String message, T data) {

--- a/src/main/java/or/sopt/soptwatcha/common/response/BaseResponse.java
+++ b/src/main/java/or/sopt/soptwatcha/common/response/BaseResponse.java
@@ -1,8 +1,11 @@
 package or.sopt.soptwatcha.common.response;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+@Getter
 @JsonPropertyOrder({"success", "code", "message", "data"})
 public class BaseResponse<T> {
     private final Boolean success;
@@ -10,31 +13,26 @@ public class BaseResponse<T> {
     private final String message;
     private final T data;
 
-    private BaseResponse(T data) {
-        this.success = true;
-        this.code = HttpStatus.OK.value();
-        this.message = "요청에 성공하였습니다.";
+    private BaseResponse(Boolean success, int code, String message, T data) {
+        this.success = success;
+        this.code = code;
+        this.message = message;
         this.data = data;
     }
 
-    public Boolean getSuccess() {
-        return success;
-    }
-
-    public int getCode() {
-        return code;
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
-    public T getData() {
-        return data;
-    }
-
     public static <T> BaseResponse<T> ok(T data) {
-        return new BaseResponse<>(data);
+        return new BaseResponse<>(true, HttpStatus.OK.value(), "요청에 성공하였습니다.", data);
     }
 
+    public static <T> BaseResponse<T> ok(String message, T data) {
+        return new BaseResponse<>(true, HttpStatus.OK.value(), message, data);
+    }
+
+    public static <T> BaseResponse<T> created(T data) {
+        return new BaseResponse<>(true, HttpStatus.CREATED.value(), "리소스가 생성되었습니다.", data);
+    }
+
+    public static BaseResponse<?> noContent() {
+        return new BaseResponse<>(true, HttpStatus.NO_CONTENT.value(), "요청을 처리했습니다.", null);
+    }
 }


### PR DESCRIPTION
## ✨ Issue

- #16 

<br>

## 📕 Summary

- API 요청/응답 패턴 통일을 위한 공통 응답 클래스 구현
- 예외 처리를 위한 통합 시스템 구축
- HTTP 상태 코드와 비즈니스 오류 코드 연동 처리
- 개발자 및 클라이언트 친화적인 오류 메시지 시스템 도입

<br>

## 🖥️ Describe your code

- 성공 응답을 위한 클래스 구현 `BaseResponse<T>`
    - 상황별 정적 팩토리 메서드 제공 (`ok()`, `created()`, `noContent()` 까지 구현해놓았습니다.)
    - `@JsonInclude`를 사용하여 null 값 필드 생략 처리를 하였는데, 어떻게 생각하시는지 궁금합니다.

- 오류 응답을 위한 클래스 구현 `BaseErrorResponse`
    - 타임스탬프 포함으로 오류 발생 시점 추적 가능

- 표준화된 오류 코드 시스템 정의 `ErrorCode`
    - HTTP 상태 코드와 비즈니스 오류 코드 매핑
    - 오류 유형별 분류 (클라이언트 오류, 서버 오류)
    - 도메인별 구체적인 오류 코드는 구현하면서 추가하면 될 것 같아요!
    - 또는 지금 추가했으면 하는 사항이 있다면 추가하겠습니다.

- 커스텀 예외 클래스 구현 `CustomException`
    - `ErrorCode`와 연동하여 표준화된 예외 처리 
    - 필요 시 사용자 정의 메시지 지원

- 전역 예외 처리기 구현 `GlobalControllerAdvice`
    - 모든 예외 유형에 대한 통합 처리
    - 예외 발생 시 로깅 및 적절한 응답 생성

<br>

## ✏️ What I Learned

- 구현하면서 새롭게 알게 된 점 및 트러블 슈팅

