### PR TITLE
[FEAT] 탑랭킹 조회 API 및 개봉 예정작 조회 API 구현

### DIFF
--- a/src/main/java/or/sopt/soptwatcha/controller/MovieController.java
+++ b/src/main/java/or/sopt/soptwatcha/controller/MovieController.java
@@ -31,7 +31,8 @@ public class MovieController {
 
 
     @GetMapping("posts/ranking")
-    @Operation(summary = "내가 좋아할 만한 작품 랭킹 API")
+    @Operation(summary = "내가 좋아할 만한 작품 랭킹 API",
+    description = "작품에 따른 예상 별점으로 다섯개의 작품 리스트를 반환합니다")
     public BaseResponse<GetMovieTopRankingResponseDTO.GetMovieTopRankingResponseListDTO> getRankingMovies() {
 
         GetMovieTopRankingResponseDTO.GetMovieTopRankingResponseListDTO result = movieService.getMovieTopRanking();
@@ -41,7 +42,8 @@ public class MovieController {
 
 
     @GetMapping("posts/soon")
-    @Operation(summary = "개봉 예정작 조회 API")
+    @Operation(summary = "개봉 예정작 조회 API",
+    description = "개봉예정일과 가장 가까운 작품 다섯개를 리스트로 반환합니다 <br><br> **movieType**에는 영화라면 MOVIE,시리즈라면 SERIES 를 넣어주세요")
     public BaseResponse<GetMovieSoonResponseDTO.GetMovieSoonResponseListDTO> getSoonMovies(@RequestParam String movieType) {
 
         GetMovieSoonResponseDTO.GetMovieSoonResponseListDTO result = movieService.getSoon(movieType);

--- a/src/main/java/or/sopt/soptwatcha/controller/MovieController.java
+++ b/src/main/java/or/sopt/soptwatcha/controller/MovieController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "영화 관련 API")
 public class MovieController {
 
+
     private final MovieService movieService;
 
 
@@ -26,6 +27,7 @@ public class MovieController {
 
         return movieService.getPreferenceMovies(commentId);
     }
+
 
     @GetMapping("posts/ranking")
     @Operation(summary = "내가 좋아할 만한 작품 랭킹 API")

--- a/src/main/java/or/sopt/soptwatcha/controller/MovieController.java
+++ b/src/main/java/or/sopt/soptwatcha/controller/MovieController.java
@@ -3,6 +3,7 @@ package or.sopt.soptwatcha.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import or.sopt.soptwatcha.common.response.BaseResponse;
 import or.sopt.soptwatcha.dto.response.GetMovieSoonResponseDTO;
 import or.sopt.soptwatcha.dto.response.GetMovieTopRankingResponseDTO;
 import or.sopt.soptwatcha.dto.response.GetPreferenceMoviesListResponse;
@@ -21,24 +22,30 @@ public class MovieController {
 
     @GetMapping("posts/preference/{commentId}")
     @Operation(summary = "코멘트를 남긴 영화 기반 추천 API")
-    public GetPreferenceMoviesListResponse getPreferenceMovies(@PathVariable Long commentId) {
+    public BaseResponse<GetPreferenceMoviesListResponse> getPreferenceMovies(@PathVariable Long commentId) {
 
-        return movieService.getPreferenceMovies(commentId);
+        GetPreferenceMoviesListResponse result = movieService.getPreferenceMovies(commentId);
+
+        return BaseResponse.ok(result);
     }
 
 
     @GetMapping("posts/ranking")
     @Operation(summary = "내가 좋아할 만한 작품 랭킹 API")
-    public GetMovieTopRankingResponseDTO.GetMovieTopRankingResponseListDTO getRankingMovies() {
+    public BaseResponse<GetMovieTopRankingResponseDTO.GetMovieTopRankingResponseListDTO> getRankingMovies() {
 
-        return movieService.getMovieTopRanking();
+        GetMovieTopRankingResponseDTO.GetMovieTopRankingResponseListDTO result = movieService.getMovieTopRanking();
+
+        return BaseResponse.ok(result);
     }
 
 
     @GetMapping("posts/soon")
     @Operation(summary = "개봉 예정작 조회 API")
-    public GetMovieSoonResponseDTO.GetMovieSoonResponseListDTO getSoonMovies(@RequestParam String movieType) {
+    public BaseResponse<GetMovieSoonResponseDTO.GetMovieSoonResponseListDTO> getSoonMovies(@RequestParam String movieType) {
 
-        return movieService.getSoon(movieType);
+        GetMovieSoonResponseDTO.GetMovieSoonResponseListDTO result = movieService.getSoon(movieType);
+
+        return BaseResponse.ok(result);
     }
 }

--- a/src/main/java/or/sopt/soptwatcha/controller/MovieController.java
+++ b/src/main/java/or/sopt/soptwatcha/controller/MovieController.java
@@ -3,13 +3,11 @@ package or.sopt.soptwatcha.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import or.sopt.soptwatcha.dto.response.GetMovieSoonResponseDTO;
 import or.sopt.soptwatcha.dto.response.GetMovieTopRankingResponseDTO;
 import or.sopt.soptwatcha.dto.response.GetPreferenceMoviesListResponse;
 import or.sopt.soptwatcha.service.MovieService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("")
@@ -34,5 +32,13 @@ public class MovieController {
     public GetMovieTopRankingResponseDTO.GetMovieTopRankingResponseListDTO getRankingMovies() {
 
         return movieService.getMovieTopRanking();
+    }
+
+
+    @GetMapping("posts/soon")
+    @Operation(summary = "개봉 예정작 조회 API")
+    public GetMovieSoonResponseDTO.GetMovieSoonResponseListDTO getSoonMovies(@RequestParam String movieType) {
+
+        return movieService.getSoon(movieType);
     }
 }

--- a/src/main/java/or/sopt/soptwatcha/controller/MovieController.java
+++ b/src/main/java/or/sopt/soptwatcha/controller/MovieController.java
@@ -3,6 +3,7 @@ package or.sopt.soptwatcha.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import or.sopt.soptwatcha.dto.response.GetMovieTopRankingResponseDTO;
 import or.sopt.soptwatcha.dto.response.GetPreferenceMoviesListResponse;
 import or.sopt.soptwatcha.service.MovieService;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,5 +25,12 @@ public class MovieController {
     public GetPreferenceMoviesListResponse getPreferenceMovies(@PathVariable Long commentId) {
 
         return movieService.getPreferenceMovies(commentId);
+    }
+
+    @GetMapping("posts/ranking")
+    @Operation(summary = "내가 좋아할 만한 작품 랭킹 API")
+    public GetMovieTopRankingResponseDTO.GetMovieTopRankingResponseListDTO getRankingMovies() {
+
+        return movieService.getMovieTopRanking();
     }
 }

--- a/src/main/java/or/sopt/soptwatcha/domain/Keyword.java
+++ b/src/main/java/or/sopt/soptwatcha/domain/Keyword.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import or.sopt.soptwatcha.domain.common.enums.Category;
 import or.sopt.soptwatcha.domain.common.enums.IsPositive;
+import or.sopt.soptwatcha.domain.common.enums.UpperCategory;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/or/sopt/soptwatcha/domain/Movie.java
+++ b/src/main/java/or/sopt/soptwatcha/domain/Movie.java
@@ -34,9 +34,6 @@ public class Movie extends BaseEntity {
 
     private double score;
 
-    // 예상 별점 필드
-    private double expectScore;
-
     private int isWished;
 
     private String details;

--- a/src/main/java/or/sopt/soptwatcha/domain/Movie.java
+++ b/src/main/java/or/sopt/soptwatcha/domain/Movie.java
@@ -34,6 +34,9 @@ public class Movie extends BaseEntity {
 
     private double score;
 
+    // 예상 별점 필드
+    private double expectScore;
+
     private int isWished;
 
     private String details;

--- a/src/main/java/or/sopt/soptwatcha/domain/common/enums/Category.java
+++ b/src/main/java/or/sopt/soptwatcha/domain/common/enums/Category.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum Category {
-    MOVIE_KEYWORD("영화 사용되는 키워드"),
+    MOVIE_KEYWORD("영화에 사용되는 키워드"),
     COMMENT_KEYWORD("댓글에 사용되는 키워드");
 
     private final String description;

--- a/src/main/java/or/sopt/soptwatcha/domain/common/enums/UpperCategory.java
+++ b/src/main/java/or/sopt/soptwatcha/domain/common/enums/UpperCategory.java
@@ -1,4 +1,4 @@
-package or.sopt.soptwatcha.domain;
+package or.sopt.soptwatcha.domain.common.enums;
 
 import lombok.Getter;
 

--- a/src/main/java/or/sopt/soptwatcha/dto/response/GetMovieSoonResponseDTO.java
+++ b/src/main/java/or/sopt/soptwatcha/dto/response/GetMovieSoonResponseDTO.java
@@ -1,0 +1,52 @@
+package or.sopt.soptwatcha.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import or.sopt.soptwatcha.domain.Movie;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GetMovieSoonResponseDTO {
+
+    private int untilRelease;
+
+    private int isWishedCount;
+
+    private String imagePath;
+
+    private String title;
+
+    private LocalDate releaseYear;
+
+    public static GetMovieSoonResponseDTO from(Movie movie, String imagePath,int untilRelease) {
+
+        return GetMovieSoonResponseDTO.builder()
+                .untilRelease(untilRelease)
+                .isWishedCount(movie.getIsWished())
+                .imagePath(imagePath)
+                .title(movie.getTitle())
+                .releaseYear(movie.getReleaseYear())
+                .build();
+    }
+
+
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class GetMovieSoonResponseListDTO{
+
+        private List<GetMovieSoonResponseDTO> soons;
+
+    }
+}
+
+

--- a/src/main/java/or/sopt/soptwatcha/dto/response/GetMovieTopRankingResponseDTO.java
+++ b/src/main/java/or/sopt/soptwatcha/dto/response/GetMovieTopRankingResponseDTO.java
@@ -28,7 +28,7 @@ public class GetMovieTopRankingResponseDTO {
         return GetMovieTopRankingResponseDTO.builder()
                 .movieImagePath(movieImagePaths)
                 .movieTitle(movie.getTitle())
-                .expectScore(movie.getExpectScore())
+                .expectScore(movie.getScore())
                 .movieKeywordList(keywords)
                 .build();
     }

--- a/src/main/java/or/sopt/soptwatcha/dto/response/GetMovieTopRankingResponseDTO.java
+++ b/src/main/java/or/sopt/soptwatcha/dto/response/GetMovieTopRankingResponseDTO.java
@@ -1,0 +1,45 @@
+package or.sopt.soptwatcha.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import or.sopt.soptwatcha.domain.Keyword;
+import or.sopt.soptwatcha.domain.Movie;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GetMovieTopRankingResponseDTO {
+
+    private String movieImagePath;
+
+    private String movieTitle;
+
+    private double expectScore;
+
+    private List<String> movieKeywordList;
+
+    public static GetMovieTopRankingResponseDTO from(Movie movie,String movieImagePaths, List<String> keywords) {
+
+        return GetMovieTopRankingResponseDTO.builder()
+                .movieImagePath(movieImagePaths)
+                .movieTitle(movie.getTitle())
+                .expectScore(movie.getExpectScore())
+                .movieKeywordList(keywords)
+                .build();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class GetMovieTopRankingResponseListDTO{
+
+        private List<GetMovieTopRankingResponseDTO> result;
+
+    }
+}

--- a/src/main/java/or/sopt/soptwatcha/repository/MovieRepository.java
+++ b/src/main/java/or/sopt/soptwatcha/repository/MovieRepository.java
@@ -3,5 +3,10 @@ package or.sopt.soptwatcha.repository;
 import or.sopt.soptwatcha.domain.Movie;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MovieRepository extends JpaRepository<Movie, Long> {
+
+    List<Movie> findTop5ByOrderByExpectScoreDesc();
+
 }

--- a/src/main/java/or/sopt/soptwatcha/repository/MovieRepository.java
+++ b/src/main/java/or/sopt/soptwatcha/repository/MovieRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface MovieRepository extends JpaRepository<Movie, Long> {
 
-    List<Movie> findTop5ByOrderByExpectScoreDesc();
+    List<Movie> findTop5ByOrderByScoreDesc();
 
     @Query(
             value = "SELECT * FROM movie WHERE movie_type = :movieType " +

--- a/src/main/java/or/sopt/soptwatcha/repository/MovieRepository.java
+++ b/src/main/java/or/sopt/soptwatcha/repository/MovieRepository.java
@@ -2,11 +2,22 @@ package or.sopt.soptwatcha.repository;
 
 import or.sopt.soptwatcha.domain.Movie;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface MovieRepository extends JpaRepository<Movie, Long> {
 
     List<Movie> findTop5ByOrderByExpectScoreDesc();
+
+    @Query(
+            value = "SELECT * FROM movie WHERE movie_type = :movieType " +
+                    "ORDER BY ABS(DATEDIFF(release_year, :targetDate)) ASC LIMIT 5",
+            nativeQuery = true
+    )
+    List<Movie> findTop5ByClosestToDateAndMovieType(@Param("targetDate") LocalDate targetDate,
+                                                    @Param("movieType") String movieType);
 
 }

--- a/src/main/java/or/sopt/soptwatcha/service/MovieService.java
+++ b/src/main/java/or/sopt/soptwatcha/service/MovieService.java
@@ -1,8 +1,13 @@
 package or.sopt.soptwatcha.service;
 
+import or.sopt.soptwatcha.dto.response.GetMovieTopRankingResponseDTO;
 import or.sopt.soptwatcha.dto.response.GetPreferenceMoviesListResponse;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface MovieService {
     GetPreferenceMoviesListResponse getPreferenceMovies(Long commentId);
+
+    @Transactional(readOnly = true)
+    GetMovieTopRankingResponseDTO.GetMovieTopRankingResponseListDTO getMovieTopRanking();
 }

--- a/src/main/java/or/sopt/soptwatcha/service/MovieService.java
+++ b/src/main/java/or/sopt/soptwatcha/service/MovieService.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface MovieService {
+
+    @Transactional(readOnly = true)
     GetPreferenceMoviesListResponse getPreferenceMovies(Long commentId);
 
     @Transactional(readOnly = true)

--- a/src/main/java/or/sopt/soptwatcha/service/MovieService.java
+++ b/src/main/java/or/sopt/soptwatcha/service/MovieService.java
@@ -1,5 +1,6 @@
 package or.sopt.soptwatcha.service;
 
+import or.sopt.soptwatcha.dto.response.GetMovieSoonResponseDTO;
 import or.sopt.soptwatcha.dto.response.GetMovieTopRankingResponseDTO;
 import or.sopt.soptwatcha.dto.response.GetPreferenceMoviesListResponse;
 import org.springframework.stereotype.Service;
@@ -10,4 +11,7 @@ public interface MovieService {
 
     @Transactional(readOnly = true)
     GetMovieTopRankingResponseDTO.GetMovieTopRankingResponseListDTO getMovieTopRanking();
+
+    @Transactional(readOnly = true)
+    GetMovieSoonResponseDTO.GetMovieSoonResponseListDTO getSoon(String movieType);
 }

--- a/src/main/java/or/sopt/soptwatcha/service/MovieServiceImpl.java
+++ b/src/main/java/or/sopt/soptwatcha/service/MovieServiceImpl.java
@@ -13,6 +13,7 @@ import or.sopt.soptwatcha.repository.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -52,6 +53,7 @@ public class MovieServiceImpl implements MovieService {
      *  6. movieKeywordRepsoitory
      * */
     @Override
+    @Transactional(readOnly = true)
     public GetPreferenceMoviesListResponse getPreferenceMovies(Long commentId) {
 
         Comment findComment = commentRepository.findById(commentId)
@@ -131,12 +133,44 @@ public class MovieServiceImpl implements MovieService {
                 })
                 .toList();
 
-        // 최종 DTO로 한 번 더 감싸기
+        // 4. 최종 DTO로 한 번 더 감싸기
         return GetMovieTopRankingResponseDTO.GetMovieTopRankingResponseListDTO.builder()
                 .result(responseList)
                 .build();
     }
 
+
+    @Override
+    @Transactional(readOnly = true)
+    public GetMovieSoonResponseDTO.GetMovieSoonResponseListDTO getSoon(String movieType) {
+
+        LocalDate now = LocalDate.now();
+
+        // 0. 무비 타입에 따른 영화 조회
+        List<Movie> top5ByClosestToDate = movieRepository.findTop5ByClosestToDateAndMovieType(now,movieType);
+
+        List<GetMovieSoonResponseDTO> responseList = top5ByClosestToDate.stream()
+                .map(movie -> {
+                    // 1. 포스터 이미지 경로 추출
+                    String posterLink = movie.getMovieImages().stream()
+                            .filter(img -> img.getMovieImageType() == MovieImageType.POSTER)
+                            .findFirst()
+                            .map(MovieImage::getImageLink)
+                            .orElse(null);
+
+                    // 2. 개봉일까지 남은 일 수 계산
+                    int untilRelease = now.until(movie.getReleaseYear()).getDays();
+
+                    // 3. DTO 변환
+                    return GetMovieSoonResponseDTO.from(movie, posterLink, untilRelease);
+                })
+                .toList();
+
+        // 4. 리스트 DTO로 감싸서 반환
+        return GetMovieSoonResponseDTO.GetMovieSoonResponseListDTO.builder()
+                .soons(responseList)
+                .build();
+    }
 
 
 

--- a/src/main/java/or/sopt/soptwatcha/service/MovieServiceImpl.java
+++ b/src/main/java/or/sopt/soptwatcha/service/MovieServiceImpl.java
@@ -4,14 +4,14 @@ import lombok.RequiredArgsConstructor;
 import or.sopt.soptwatcha.common.exception.CustomException;
 import or.sopt.soptwatcha.common.exception.ErrorCode;
 import or.sopt.soptwatcha.domain.*;
+import or.sopt.soptwatcha.domain.common.enums.Category;
 import or.sopt.soptwatcha.domain.common.enums.IsPositive;
 import or.sopt.soptwatcha.domain.common.enums.MovieImageType;
-import or.sopt.soptwatcha.dto.response.GetPreferenceMoviesListResponse;
-import or.sopt.soptwatcha.dto.response.GetPreferenceMoviesResponse;
-import or.sopt.soptwatcha.dto.response.KeywordRecommendationGroupResponse;
-import or.sopt.soptwatcha.dto.response.KeywordResponseDTO;
+import or.sopt.soptwatcha.domain.common.enums.UpperCategory;
+import or.sopt.soptwatcha.dto.response.*;
 import or.sopt.soptwatcha.repository.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -23,6 +23,7 @@ public class MovieServiceImpl implements MovieService {
     private final CommentRepository commentRepository;
     private final CommentKeywordRepository commentKeywordRepository;
     private final MovieKeywordRepository movieKeywordRepository;
+    private final MovieRepository movieRepository;
 
 
     /**
@@ -101,6 +102,39 @@ public class MovieServiceImpl implements MovieService {
         }
 
         return GetPreferenceMoviesListResponse.of(groupedResult);
+    }
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public GetMovieTopRankingResponseDTO.GetMovieTopRankingResponseListDTO getMovieTopRanking() {
+        List<Movie> top5MoviesByExpectScore = movieRepository.findTop5ByOrderByExpectScoreDesc();
+
+        List<GetMovieTopRankingResponseDTO> responseList = top5MoviesByExpectScore.stream()
+                .map(movie -> {
+                    // 1. 포스터 이미지 경로 추출
+                    String posterLink = movie.getMovieImages().stream()
+                            .filter(img -> img.getMovieImageType() == MovieImageType.POSTER)
+                            .findFirst()
+                            .map(MovieImage::getImageLink)
+                            .orElse(null);
+
+                    // 2. MOVIE_KEYWORD에 해당하는 키워드 리스트 추출
+                    List<String> movieKeywordValues = movie.getMovieKeywords().stream()
+                            .map(MovieKeyword::getKeyword)
+                            .filter(keyword -> keyword.getCategory() == Category.MOVIE_KEYWORD)
+                            .map(Keyword::getValue)
+                            .toList();
+
+                    // 3. DTO로 변환
+                    return GetMovieTopRankingResponseDTO.from(movie, posterLink, movieKeywordValues);
+                })
+                .toList();
+
+        // 최종 DTO로 한 번 더 감싸기
+        return GetMovieTopRankingResponseDTO.GetMovieTopRankingResponseListDTO.builder()
+                .result(responseList)
+                .build();
     }
 
 

--- a/src/main/java/or/sopt/soptwatcha/service/MovieServiceImpl.java
+++ b/src/main/java/or/sopt/soptwatcha/service/MovieServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -159,7 +160,7 @@ public class MovieServiceImpl implements MovieService {
                             .orElse(null);
 
                     // 2. 개봉일까지 남은 일 수 계산
-                    int untilRelease = now.until(movie.getReleaseYear()).getDays();
+                    int untilRelease = (int) ChronoUnit.DAYS.between(now, movie.getReleaseYear());
 
                     // 3. DTO 변환
                     return GetMovieSoonResponseDTO.from(movie, posterLink, untilRelease);

--- a/src/main/java/or/sopt/soptwatcha/service/MovieServiceImpl.java
+++ b/src/main/java/or/sopt/soptwatcha/service/MovieServiceImpl.java
@@ -85,7 +85,7 @@ public class MovieServiceImpl implements MovieService {
     @Override
     @Transactional(readOnly = true)
     public GetMovieTopRankingResponseDTO.GetMovieTopRankingResponseListDTO getMovieTopRanking() {
-        List<Movie> top5MoviesByExpectScore = movieRepository.findTop5ByOrderByExpectScoreDesc();
+        List<Movie> top5MoviesByExpectScore = movieRepository.findTop5ByOrderByScoreDesc();
 
         List<GetMovieTopRankingResponseDTO> responseList = top5MoviesByExpectScore.stream()
                 .map(movie -> {

--- a/src/main/java/or/sopt/soptwatcha/service/MovieServiceImpl.java
+++ b/src/main/java/or/sopt/soptwatcha/service/MovieServiceImpl.java
@@ -24,35 +24,9 @@ public class MovieServiceImpl implements MovieService {
 
     private final CommentRepository commentRepository;
     private final CommentKeywordRepository commentKeywordRepository;
-    private final MovieKeywordRepository movieKeywordRepository;
     private final MovieRepository movieRepository;
 
 
-    /**
-     * 1. 파라미터로 코멘트 식별자를 받아서
-     * 2. 해당 코멘트가 존재하는 키워드를 찾는다
-     * 3. 그리고 그 키워드들을
-     *  3-1. 긍정/부정으로 가르고 부정은 날려버림
-     *  3-2. 키워드 별로 우선순위를 책정함
-     *
-     * 아 이렇게 하면 안되는 것 같은데
-     * 이렇게 하는게 아니라 해당 키워드를 매핑하고 있는 코멘트를 전부 찾아서
-     * 그 코멘트가 달린 영화를 모두 찾아서
-     * 그 영화 중 다섯개를 리스트업 해야함
-     *
-     * 4. 그리고 그 키워드대로 Movie에 어떤게 매핑되어 있는지 찾아보고 상위 다섯개 리스트업 -> X
-     *  4-1. 이때 DTO 하나 쓰고
-     * 5. 그리고 그걸 전부 감싸서 반환
-     *  5-1. 이때 DTO 하나 더
-     *
-     * 그럼 필요한 repository가
-     *  1. commentRepository
-     *  2. commentKeywordRepository
-     *  3. keywordRepository
-     *  4. movieRepository
-     *  5. movieImageRepository
-     *  6. movieKeywordRepsoitory
-     * */
     @Override
     @Transactional(readOnly = true)
     public GetPreferenceMoviesListResponse getPreferenceMovies(Long commentId) {

--- a/src/test/java/or/sopt/soptwatcha/service/MovieServiceImplTest.java
+++ b/src/test/java/or/sopt/soptwatcha/service/MovieServiceImplTest.java
@@ -5,9 +5,7 @@ import or.sopt.soptwatcha.common.exception.ErrorCode;
 import or.sopt.soptwatcha.domain.*;
 import or.sopt.soptwatcha.domain.common.enums.Category;
 import or.sopt.soptwatcha.domain.common.enums.IsPositive;
-import or.sopt.soptwatcha.dto.response.GetPreferenceMoviesListResponse;
-import or.sopt.soptwatcha.dto.response.GetPreferenceMoviesResponse;
-import or.sopt.soptwatcha.dto.response.KeywordRecommendationGroupResponse;
+import or.sopt.soptwatcha.domain.common.enums.UpperCategory;
 import or.sopt.soptwatcha.repository.CommentKeywordRepository;
 import or.sopt.soptwatcha.repository.CommentRepository;
 import or.sopt.soptwatcha.repository.MovieKeywordRepository;
@@ -18,7 +16,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 

--- a/src/test/java/or/sopt/soptwatcha/service/MovieServiceImplTest.java
+++ b/src/test/java/or/sopt/soptwatcha/service/MovieServiceImplTest.java
@@ -9,6 +9,7 @@ import or.sopt.soptwatcha.domain.common.enums.UpperCategory;
 import or.sopt.soptwatcha.repository.CommentKeywordRepository;
 import or.sopt.soptwatcha.repository.CommentRepository;
 import or.sopt.soptwatcha.repository.MovieKeywordRepository;
+import or.sopt.soptwatcha.repository.MovieRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,9 @@ class MovieServiceImplTest {
     @Mock
     MovieKeywordRepository movieKeywordRepository;
 
+    @Mock
+    MovieRepository movieRepository;
+
     @InjectMocks
     MovieServiceImpl movieService;
 
@@ -48,7 +52,8 @@ class MovieServiceImplTest {
         movieService = Mockito.spy(new MovieServiceImpl(
                 commentRepository,
                 commentKeywordRepository,
-                movieKeywordRepository
+                movieKeywordRepository,
+                movieRepository
         ));
     }
 


### PR DESCRIPTION
## ✨ Issue

- #13 

<br>

## 📕 Summary

- 탑랭킹 조회 API 및 개봉 예정작 조회 API 구현

<br>

## 🖥️ Describe your code

- 개발일정이 빠듯해져서 하나의 이슈에서 구현을 마무리 하였습니다
- 테스트코드를 따로 작성할 틈이 없어서 더미데이터를 추가하고, 스웨거에서 테스트를 하였습니다
- https://typical-nurse-037.notion.site/API-1f85a5f681b580f79559d73247e97492?pvs=4
- 테스트에 대한 과정을 스웨거로 정리하였습니다

<br>

- 추후에 다양한 예외로직을 설정하는 작업을 추가하고, 취향 저격 로직의 리팩터링을 하도록 하겠습니다


<br>

## ✏️ What I Learned

처음에 날짜를 계산할때 

```
int untilRelease = now.until(movie.getReleaseYear()).getDays();

```


이렇게 계산하였는데, 날짜가 이상하게 나와서 알아보니 해당 메서드는 'day'를 기준으로만 출력한다고 하더군요.
그래서 구글링해서 `ChronoUnit`이라는 의존성을 추가하여 계산을 해봤습니다.


```
int untilRelease = (int) ChronoUnit.DAYS.between(now, movie.getReleaseYear());

```

그랬더니 잘 나왔습니다. 물론 외부 의존성인 만큼, LocalDate와 함께 의존성 분리가 진행이 되어야 할 것 같습니다. 그리고 리파지토리에서도 네이티브 쿼리를 사용하였는데, 이보다는 필드에서 LocalDate로 저장하는게 아닌, 다른 자료형을 통해 계산하여 JPQL로만 계산 할 수 있도록 하는 로직으로 수정돼야 할 것 같습니다.



