### PR TITLE
[FEAT] 영화 상세정보 조회 API 구현

### DIFF
--- a/src/main/java/or/sopt/soptwatcha/controller/MovieController.java
+++ b/src/main/java/or/sopt/soptwatcha/controller/MovieController.java
@@ -19,12 +19,11 @@ import org.springframework.web.bind.annotation.*;
 public class MovieController {
 
     private final MovieService movieService;
-    private final MovieServiceImpl movieServiceImpl;
-    
+
     @GetMapping("/{postId}")
     @Operation(summary = "영화 상세 정보 조회 API")
     public BaseResponse<MovieDetailResponseDTO> getMovieDetail(@PathVariable Long postId) {
-        MovieDetailResponseDTO response = movieServiceImpl.getMovieDetail(postId);
+        MovieDetailResponseDTO response = movieService.getMovieDetail(postId);
         return BaseResponse.ok(response);
     }
 

--- a/src/main/java/or/sopt/soptwatcha/controller/MovieController.java
+++ b/src/main/java/or/sopt/soptwatcha/controller/MovieController.java
@@ -1,0 +1,28 @@
+package or.sopt.soptwatcha.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import or.sopt.soptwatcha.common.response.BaseResponse;
+import or.sopt.soptwatcha.dto.response.MovieDetailResponseDTO;
+import or.sopt.soptwatcha.service.MovieServiceImpl;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/posts")
+@RequiredArgsConstructor
+@Tag(name = "영화 관련 API")
+public class MovieController {
+
+    private final MovieServiceImpl movieService;
+
+    @Operation(summary = "영화 상세 정보 조회 API")
+    @GetMapping("/{postId}")
+    public BaseResponse<MovieDetailResponseDTO> getMovieDetail(@PathVariable Long postId) {
+        MovieDetailResponseDTO response = movieService.getMovieDetail(postId);
+        return BaseResponse.ok(response);
+    }
+}

--- a/src/main/java/or/sopt/soptwatcha/domain/common/enums/FilmCountry.java
+++ b/src/main/java/or/sopt/soptwatcha/domain/common/enums/FilmCountry.java
@@ -1,5 +1,5 @@
 package or.sopt.soptwatcha.domain.common.enums;
 
 public enum FilmCountry {
-    A
+    한국, 미국, 영국, 프랑스, 일본, 중국
 }

--- a/src/main/java/or/sopt/soptwatcha/domain/common/enums/Role.java
+++ b/src/main/java/or/sopt/soptwatcha/domain/common/enums/Role.java
@@ -1,5 +1,5 @@
 package or.sopt.soptwatcha.domain.common.enums;
 
 public enum Role {
-    A
+    DIRECTOR, ACTOR
 }

--- a/src/main/java/or/sopt/soptwatcha/dto/response/ArtistResponseDTO.java
+++ b/src/main/java/or/sopt/soptwatcha/dto/response/ArtistResponseDTO.java
@@ -1,0 +1,26 @@
+package or.sopt.soptwatcha.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import or.sopt.soptwatcha.domain.MovieArtist;
+import or.sopt.soptwatcha.domain.common.enums.Role;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ArtistResponseDTO {
+    private Role role;
+    private String name;
+    private String character;
+
+    public static ArtistResponseDTO from(MovieArtist movieArtist) {
+        return ArtistResponseDTO.builder()
+                .role(movieArtist.getRole())
+                .name(movieArtist.getArtist().getName())
+                .character(movieArtist.getCharacterName())
+                .build();
+    }
+}

--- a/src/main/java/or/sopt/soptwatcha/dto/response/MovieDetailResponseDTO.java
+++ b/src/main/java/or/sopt/soptwatcha/dto/response/MovieDetailResponseDTO.java
@@ -1,0 +1,74 @@
+package or.sopt.soptwatcha.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import or.sopt.soptwatcha.domain.Movie;
+import or.sopt.soptwatcha.domain.MovieArtist;
+import or.sopt.soptwatcha.domain.MovieGenre;
+import or.sopt.soptwatcha.domain.MovieImage;
+import or.sopt.soptwatcha.domain.common.enums.MovieImageType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MovieDetailResponseDTO {
+    private Long id;
+    private String title;
+    private String engTitle;
+    private List<String> genres;
+    private Integer releaseYear;
+    private Integer runningTime;
+    private Integer ageLimit;
+    private String detail;
+    private String posterImage;
+    private String detailImage;
+    private String country;
+    private List<ArtistResponseDTO> artists;
+
+    public static MovieDetailResponseDTO from(Movie movie, 
+                                             List<MovieGenre> movieGenres, 
+                                             List<MovieArtist> movieArtists, 
+                                             List<MovieImage> movieImages) {
+        
+        List<String> genreList = movieGenres.stream()
+                .map(movieGenre -> movieGenre.getGenre().getValue())
+                .collect(Collectors.toList());
+
+        List<ArtistResponseDTO> artistList = movieArtists.stream()
+                .map(ArtistResponseDTO::from)
+                .collect(Collectors.toList());
+
+        String posterImageUrl = movieImages.stream()
+                .filter(image -> image.getMovieImageType() == MovieImageType.POSTER)
+                .findFirst()
+                .map(MovieImage::getImageLink)
+                .orElse(null);
+
+        String detailImageUrl = movieImages.stream()
+                .filter(image -> image.getMovieImageType() == MovieImageType.DESCRIPTION)
+                .findFirst()
+                .map(MovieImage::getImageLink)
+                .orElse(null);
+
+        return MovieDetailResponseDTO.builder()
+                .id(movie.getId())
+                .title(movie.getTitle())
+                .engTitle(movie.getEngTitle())
+                .genres(genreList)
+                .releaseYear(movie.getReleaseYear().getYear())
+                .runningTime(movie.getRunningTime())
+                .ageLimit(movie.getAgeLimit())
+                .detail(movie.getDetails())
+                .posterImage(posterImageUrl)
+                .detailImage(detailImageUrl)
+                .country(movie.getFilmCountry().name())
+                .artists(artistList)
+                .build();
+    }
+}

--- a/src/main/java/or/sopt/soptwatcha/dto/response/MovieDetailResponseDTO.java
+++ b/src/main/java/or/sopt/soptwatcha/dto/response/MovieDetailResponseDTO.java
@@ -9,6 +9,7 @@ import or.sopt.soptwatcha.domain.MovieArtist;
 import or.sopt.soptwatcha.domain.MovieGenre;
 import or.sopt.soptwatcha.domain.MovieImage;
 import or.sopt.soptwatcha.domain.common.enums.MovieImageType;
+import or.sopt.soptwatcha.util.TimeFormatUtil;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -56,15 +57,13 @@ public class MovieDetailResponseDTO {
                 .map(MovieImage::getImageLink)
                 .orElse(null);
 
-        String formattedRunningTime = formatRunningTime(movie.getRunningTime());
-
         return MovieDetailResponseDTO.builder()
                 .id(movie.getId())
                 .title(movie.getTitle())
                 .engTitle(movie.getEngTitle())
                 .genres(genreList)
                 .releaseYear(movie.getReleaseYear().getYear())
-                .runningTime(formattedRunningTime)
+                .runningTime(TimeFormatUtil.formatMinutesToHoursAndMinutes(movie.getRunningTime()))
                 .ageLimit(movie.getAgeLimit())
                 .detail(movie.getDetails())
                 .posterImage(posterImageUrl)
@@ -72,19 +71,6 @@ public class MovieDetailResponseDTO {
                 .country(movie.getFilmCountry().name())
                 .artists(artistList)
                 .build();
-    }
-
-    private static String formatRunningTime(int minutes) {
-        int hours = minutes / 60;
-        int remainingMinutes = minutes % 60;
-
-        if (hours > 0 && remainingMinutes > 0) {
-            return hours + "시간 " + remainingMinutes + "분";
-        } else if (hours > 0) {
-            return hours + "시간";
-        } else {
-            return remainingMinutes + "분";
-        }
     }
 
 }

--- a/src/main/java/or/sopt/soptwatcha/dto/response/MovieDetailResponseDTO.java
+++ b/src/main/java/or/sopt/soptwatcha/dto/response/MovieDetailResponseDTO.java
@@ -23,7 +23,7 @@ public class MovieDetailResponseDTO {
     private String engTitle;
     private List<String> genres;
     private Integer releaseYear;
-    private Integer runningTime;
+    private String runningTime;
     private Integer ageLimit;
     private String detail;
     private String posterImage;
@@ -56,13 +56,15 @@ public class MovieDetailResponseDTO {
                 .map(MovieImage::getImageLink)
                 .orElse(null);
 
+        String formattedRunningTime = formatRunningTime(movie.getRunningTime());
+
         return MovieDetailResponseDTO.builder()
                 .id(movie.getId())
                 .title(movie.getTitle())
                 .engTitle(movie.getEngTitle())
                 .genres(genreList)
                 .releaseYear(movie.getReleaseYear().getYear())
-                .runningTime(movie.getRunningTime())
+                .runningTime(formattedRunningTime)
                 .ageLimit(movie.getAgeLimit())
                 .detail(movie.getDetails())
                 .posterImage(posterImageUrl)
@@ -71,4 +73,18 @@ public class MovieDetailResponseDTO {
                 .artists(artistList)
                 .build();
     }
+
+    private static String formatRunningTime(int minutes) {
+        int hours = minutes / 60;
+        int remainingMinutes = minutes % 60;
+
+        if (hours > 0 && remainingMinutes > 0) {
+            return hours + "시간 " + remainingMinutes + "분";
+        } else if (hours > 0) {
+            return hours + "시간";
+        } else {
+            return remainingMinutes + "분";
+        }
+    }
+
 }

--- a/src/main/java/or/sopt/soptwatcha/repository/GenreRepository.java
+++ b/src/main/java/or/sopt/soptwatcha/repository/GenreRepository.java
@@ -1,0 +1,7 @@
+package or.sopt.soptwatcha.repository;
+
+import or.sopt.soptwatcha.domain.Genre;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GenreRepository extends JpaRepository<Genre, Long> {
+}

--- a/src/main/java/or/sopt/soptwatcha/repository/MovieArtistRepository.java
+++ b/src/main/java/or/sopt/soptwatcha/repository/MovieArtistRepository.java
@@ -1,0 +1,11 @@
+package or.sopt.soptwatcha.repository;
+
+import or.sopt.soptwatcha.domain.Movie;
+import or.sopt.soptwatcha.domain.MovieArtist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MovieArtistRepository extends JpaRepository<MovieArtist, Long> {
+    List<MovieArtist> findAllByMovie(Movie movie);
+}

--- a/src/main/java/or/sopt/soptwatcha/repository/MovieGenreRepository.java
+++ b/src/main/java/or/sopt/soptwatcha/repository/MovieGenreRepository.java
@@ -1,0 +1,11 @@
+package or.sopt.soptwatcha.repository;
+
+import or.sopt.soptwatcha.domain.Movie;
+import or.sopt.soptwatcha.domain.MovieGenre;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MovieGenreRepository extends JpaRepository<MovieGenre, Long> {
+    List<MovieGenre> findAllByMovie(Movie movie);
+}

--- a/src/main/java/or/sopt/soptwatcha/repository/MovieImageRepository.java
+++ b/src/main/java/or/sopt/soptwatcha/repository/MovieImageRepository.java
@@ -1,11 +1,14 @@
 package or.sopt.soptwatcha.repository;
 
+import or.sopt.soptwatcha.domain.Movie;
 import or.sopt.soptwatcha.domain.MovieImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MovieImageRepository extends JpaRepository<MovieImage, Long> {
 
     Optional<MovieImage> findByFileName(String filename);
+    List<MovieImage> findAllByMovie(Movie movie);
 }

--- a/src/main/java/or/sopt/soptwatcha/service/MovieService.java
+++ b/src/main/java/or/sopt/soptwatcha/service/MovieService.java
@@ -3,7 +3,7 @@ package or.sopt.soptwatcha.service;
 import or.sopt.soptwatcha.dto.response.GetMovieSoonResponseDTO;
 import or.sopt.soptwatcha.dto.response.GetMovieTopRankingResponseDTO;
 import or.sopt.soptwatcha.dto.response.GetPreferenceMoviesListResponse;
-import org.springframework.stereotype.Service;
+import or.sopt.soptwatcha.dto.response.MovieDetailResponseDTO;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface MovieService {
@@ -16,4 +16,7 @@ public interface MovieService {
 
     @Transactional(readOnly = true)
     GetMovieSoonResponseDTO.GetMovieSoonResponseListDTO getSoon(String movieType);
+
+    @Transactional(readOnly = true)
+    MovieDetailResponseDTO getMovieDetail(Long postId);
 }

--- a/src/main/java/or/sopt/soptwatcha/service/MovieServiceImpl.java
+++ b/src/main/java/or/sopt/soptwatcha/service/MovieServiceImpl.java
@@ -1,0 +1,42 @@
+package or.sopt.soptwatcha.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import or.sopt.soptwatcha.common.exception.CustomException;
+import or.sopt.soptwatcha.common.exception.ErrorCode;
+import or.sopt.soptwatcha.domain.Movie;
+import or.sopt.soptwatcha.domain.MovieArtist;
+import or.sopt.soptwatcha.domain.MovieGenre;
+import or.sopt.soptwatcha.domain.MovieImage;
+import or.sopt.soptwatcha.dto.response.MovieDetailResponseDTO;
+import or.sopt.soptwatcha.repository.MovieArtistRepository;
+import or.sopt.soptwatcha.repository.MovieGenreRepository;
+import or.sopt.soptwatcha.repository.MovieImageRepository;
+import or.sopt.soptwatcha.repository.MovieRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class MovieServiceImpl {
+
+    private final MovieRepository movieRepository;
+    private final MovieGenreRepository movieGenreRepository;
+    private final MovieArtistRepository movieArtistRepository;
+    private final MovieImageRepository movieImageRepository;
+
+    public MovieDetailResponseDTO getMovieDetail(Long movieId) {
+        Movie movie = movieRepository.findById(movieId)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REQUEST, "해당 영화를 찾을 수 없습니다."));
+
+        List<MovieGenre> movieGenres = movieGenreRepository.findAllByMovie(movie);
+        List<MovieArtist> movieArtists = movieArtistRepository.findAllByMovie(movie);
+        List<MovieImage> movieImages = movieImageRepository.findAllByMovie(movie);
+
+        return MovieDetailResponseDTO.from(movie, movieGenres, movieArtists, movieImages);
+    }
+}

--- a/src/main/java/or/sopt/soptwatcha/util/TimeFormatUtil.java
+++ b/src/main/java/or/sopt/soptwatcha/util/TimeFormatUtil.java
@@ -1,0 +1,17 @@
+package or.sopt.soptwatcha.util;
+
+public class TimeFormatUtil {
+    
+    public static String formatMinutesToHoursAndMinutes(int minutes) {
+        int hours = minutes / 60;
+        int remainingMinutes = minutes % 60;
+        
+        if (hours > 0 && remainingMinutes > 0) {
+            return hours + "시간 " + remainingMinutes + "분";
+        } else if (hours > 0) {
+            return hours + "시간";
+        } else {
+            return remainingMinutes + "분";
+        }
+    }
+}


### PR DESCRIPTION
## ✨ Issue

- #19 

<br>

## 📕 Summary

- 영화 ID를 받아 해당 영화의 상세 정보를 조회하는 API를 구현하였습니다.
- 홈에서 영화를 눌렀을 때 영화에 대한 자세한 정보를 모두 조회하여 응답합니다.
- Integer 타입으로 저장되어 있던 실행시간(runningTime)을 "시간 분" 형태의 문자열로 변환하여 제공합니다.

<br>

## 🖥️ Describe your code
- **영화 상세 정보 조회 API 구현**
    - `GET /posts/{postId}` 엔드포인트를 통해 영화 상세 정보를 조회할 수 있습니다.
    - 영화 기본 정보(제목, 개봉일, 연령 제한 등)와 함께 장르, 출연진, 이미지 정보를 포함합니다.
    - 존재하지 않는 영화 ID를 요청할 경우 적절한 예외 처리를 제공합니다.

- **시간 포맷팅 유틸리티 분리**
    - 실행시간(분)을 "시간 분" 형식으로 변환하는 클래스를 구현하였습니다. `TimeFormatUtil`
    - 예: 90분 → "1시간 30분"

- **국가 정보 Enum 처리**
    - 우선은 enum을 한글 값으로 정의하여 직관적인 데이터 관리가 가능하도록 구현하였습니다. `FilmCountry`
    - KOR, USA 등의 코드값으로 변경하고 표시 이름을 별도 관리하는 방식이 나을지에 대해 고민중입니다.
      - 재연님의 생각이 궁금합니다!

<br>

## ✏️ What I Learned
- DTO에서의 비즈니스 로직 처리
    - 현재 응답 데이터 구성의 책임을 DTO에 부여하여 `MovieDetailResponseDTO`에서 여러 엔티티의 데이터를 조합하고 변환하는 작업을 수행하고 있습니다. 
    - 복잡도가 증가할 경우에 대해 고민이 되긴 하는데, 추후 다시 생각해보겠습니다.

- Enum 설계에 대한 고민
    - 표시 이름은 별도로 관리하는 것이 더 유연한 설계가 될 것으로 판단됩니다.


