### PR TITLE
[FEAT] 영화 인기 코멘트 조회 API 구현

### DIFF
--- a/src/main/java/or/sopt/soptwatcha/common/exception/ErrorCode.java
+++ b/src/main/java/or/sopt/soptwatcha/common/exception/ErrorCode.java
@@ -13,6 +13,9 @@ public enum ErrorCode {
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된.파라미터입니다."),
 
+    // 영화 관련 클라이언트 오류 - 400번대
+    MOVIE_NOT_FOUND(HttpStatus.NOT_FOUND, "영화를 찾을 수 없습니다"),
+
     // 코멘트 관련 클라이언트 오류 - 400번대
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND,"댓글을 찾을 수 없습니다"),
 

--- a/src/main/java/or/sopt/soptwatcha/controller/CommentController.java
+++ b/src/main/java/or/sopt/soptwatcha/controller/CommentController.java
@@ -1,0 +1,25 @@
+package or.sopt.soptwatcha.controller;
+
+import lombok.RequiredArgsConstructor;
+import or.sopt.soptwatcha.common.response.BaseResponse;
+import or.sopt.soptwatcha.dto.response.CommentResponseDTO;
+import or.sopt.soptwatcha.service.CommentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/posts")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @GetMapping("/{postId}/comments")
+    public ResponseEntity<BaseResponse<CommentResponseDTO>> getTopLikedComment(@PathVariable("postId") Long movieId) {
+        CommentResponseDTO responseDto = commentService.getTopLikedComment(movieId);
+        return ResponseEntity.ok(BaseResponse.ok(responseDto));
+    }
+}

--- a/src/main/java/or/sopt/soptwatcha/dto/response/CommentResponseDTO.java
+++ b/src/main/java/or/sopt/soptwatcha/dto/response/CommentResponseDTO.java
@@ -1,0 +1,25 @@
+package or.sopt.soptwatcha.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import or.sopt.soptwatcha.domain.Comment;
+
+@Getter
+@Builder
+public class CommentResponseDTO {
+    private Long id;
+    private double score;
+    private String content;
+    private int likeCount;
+    private int replyCount;
+
+    public static CommentResponseDTO of(Comment comment) {
+        return CommentResponseDTO.builder()
+                .id(comment.getId())
+                .score(comment.getScore())
+                .content(comment.getReview())
+                .likeCount(comment.getLikeCount())
+                .replyCount(comment.getReplyCount())
+                .build();
+    }
+}

--- a/src/main/java/or/sopt/soptwatcha/repository/CommentRepository.java
+++ b/src/main/java/or/sopt/soptwatcha/repository/CommentRepository.java
@@ -3,5 +3,8 @@ package or.sopt.soptwatcha.repository;
 import or.sopt.soptwatcha.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    Optional<Comment> findTopByMovieIdOrderByLikeCountDesc(Long movieId);
 }

--- a/src/main/java/or/sopt/soptwatcha/service/CommentService.java
+++ b/src/main/java/or/sopt/soptwatcha/service/CommentService.java
@@ -1,0 +1,31 @@
+package or.sopt.soptwatcha.service;
+
+import lombok.RequiredArgsConstructor;
+import or.sopt.soptwatcha.common.exception.ErrorCode;
+import or.sopt.soptwatcha.common.exception.CustomException;
+import or.sopt.soptwatcha.domain.Comment;
+import or.sopt.soptwatcha.dto.response.CommentResponseDTO;
+import or.sopt.soptwatcha.repository.CommentRepository;
+import or.sopt.soptwatcha.repository.MovieRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final MovieRepository movieRepository;
+
+    @Transactional(readOnly = true)
+    public CommentResponseDTO getTopLikedComment(Long movieId) {
+        if (!movieRepository.existsById(movieId)) {
+            throw new CustomException(ErrorCode.MOVIE_NOT_FOUND);
+        }
+
+        Comment comment = commentRepository.findTopByMovieIdOrderByLikeCountDesc(movieId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        return CommentResponseDTO.of(comment);
+    }
+}


### PR DESCRIPTION
## ✨ Issue

- #25 

<br>

## 📕 Summary

- 영화 상세 정보 조회 시 해당 영화에 대한 가장 인기 있는 코멘트(좋아요가 가장 많은) 조회 API를 구현했습니다.
- 영화 또는 코멘트가 존재하지 않는 경우에 대한 예외 처리를 추가 및 구현했습니다.

<br>

## 🖥️ Describe your code

- `GET /posts/{postId}/comments`: 특정 영화에 대한 가장 좋아요가 많은 코멘트 하나를 반환하는 API를 구현했습니다.
- API 응답으로는 코멘트의 id, 평점, 내용, 좋아요 수, 답글 수를 포함하여 구성했습니다.

- `CommentService`에서 영화의 존재 여부를 먼저 확인한 후 코멘트를 조회합니다. 
- 영화나 코멘트가 존재하지 않는 경우 적절한 예외를 발생시키도록 구현했습니다.

Spring Data JPA의 메서드 이름 규칙 활용
- `findTopByMovieIdOrderByLikeCountDesc` 메서드 이름만으로 필요한 쿼리를 생성하는게 좋을지, 복잡한 JPQL이나 네이티브 SQL을 사용하는게 좋을지 고민했습니다.
- 현재는 메서드 이름 규칙을 사용하는것만으로도 충분하고 적합하다 판단하였습니다.


<br>

## ✏️ What I Learned

### Spring Data JPA의 메서드 이름 규칙 활용
- 이 방식은 코드의 가독성을 높이고, 타입 안전성을 보장하며, 유지보수성을 향상시킵니다.

### 쿼리 최적화 관련 고민
- 대규모 시스템에서는 `movie_id`와 `like_count`에 대한 복합 인덱스를 생성하여 성능을 최적화할 수 있다는 점을 고려했습니다. 
- 하지만 현재 상황에서는 메서드 이름 규칙을 활용한 방식으로도 충분히 효율적이라고 판단했습니다.
- 필요한 경우에만 네이티브 SQL로 전환하는 것이 더 실용적인 접근 방식임을 될 수 있을 것 같습니다.


