### PR TITLE
[FIX] 선호 태그 리스트 반환 추가

### DIFF
--- a/src/main/java/or/sopt/soptwatcha/domain/common/enums/FilmCountry.java
+++ b/src/main/java/or/sopt/soptwatcha/domain/common/enums/FilmCountry.java
@@ -1,5 +1,23 @@
 package or.sopt.soptwatcha.domain.common.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum FilmCountry {
-    한국, 미국, 영국, 프랑스, 일본, 중국
+    KOR("한국"),
+    USA("미국"),
+    GBR("영국"),
+    FRA("프랑스"),
+    JPN("일본"),
+    CHN("중국");
+
+    private final String koreanName;
+
+    FilmCountry(String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    public String getDisplayName() {
+        return this.koreanName;
+    }
 }

--- a/src/main/java/or/sopt/soptwatcha/dto/response/MovieDetailResponseDTO.java
+++ b/src/main/java/or/sopt/soptwatcha/dto/response/MovieDetailResponseDTO.java
@@ -76,7 +76,7 @@ public class MovieDetailResponseDTO {
                 .detail(movie.getDetails())
                 .posterImage(posterImageUrl)
                 .detailImage(detailImageUrl)
-                .country(movie.getFilmCountry().name())
+                .country(movie.getFilmCountry().getDisplayName())
                 .artists(artistList)
                 .keywords(keywordList)
                 .build();

--- a/src/main/java/or/sopt/soptwatcha/dto/response/MovieDetailResponseDTO.java
+++ b/src/main/java/or/sopt/soptwatcha/dto/response/MovieDetailResponseDTO.java
@@ -8,6 +8,7 @@ import or.sopt.soptwatcha.domain.Movie;
 import or.sopt.soptwatcha.domain.MovieArtist;
 import or.sopt.soptwatcha.domain.MovieGenre;
 import or.sopt.soptwatcha.domain.MovieImage;
+import or.sopt.soptwatcha.domain.common.enums.Category;
 import or.sopt.soptwatcha.domain.common.enums.MovieImageType;
 import or.sopt.soptwatcha.util.TimeFormatUtil;
 
@@ -31,6 +32,7 @@ public class MovieDetailResponseDTO {
     private String detailImage;
     private String country;
     private List<ArtistResponseDTO> artists;
+    private List<String> keywords;
 
     public static MovieDetailResponseDTO from(Movie movie, 
                                              List<MovieGenre> movieGenres, 
@@ -57,6 +59,12 @@ public class MovieDetailResponseDTO {
                 .map(MovieImage::getImageLink)
                 .orElse(null);
 
+        List<String> keywordList = movie.getMovieKeywords().stream()
+                .map(movieKeyword -> movieKeyword.getKeyword())
+                .filter(keyword -> keyword.getCategory() == Category.MOVIE_KEYWORD)
+                .map(keyword -> keyword.getValue())
+                .collect(Collectors.toList());
+
         return MovieDetailResponseDTO.builder()
                 .id(movie.getId())
                 .title(movie.getTitle())
@@ -70,6 +78,7 @@ public class MovieDetailResponseDTO {
                 .detailImage(detailImageUrl)
                 .country(movie.getFilmCountry().name())
                 .artists(artistList)
+                .keywords(keywordList)
                 .build();
     }
 


### PR DESCRIPTION
## ✨ Issue

- #30 

<br>

## 📕 Summary

- 영화 상세 정보 조회 API 응답에 영화 키워드 정보를 추가하였습니다.
- Category가 `MOVIE_KEYWORD`인 키워드 목록을 필터링하여 반환하도록 구현하였습니다.
- FilmCountry Enum값도 영어로 저장하도록 변경하였습니다.

<br>

## 🖥️ Describe your code

- **MovieDetailResponseDTO 수정**
    - 키워드 목록을 담을 `keywords`필드를 추가하였습니다. 
    - 영화 엔티티의 `movieKeywords`컬렉션에서 카테고리가 `MOVIE_KEYWORD`인 키워드만 필터링하여 값을 추출하도록 구현하였습니다. 

<br>

## ✏️ What I Learned


